### PR TITLE
functions.cfg autoupdate - crontab stderr to /dev/null

### DIFF
--- a/config/functions.cfg
+++ b/config/functions.cfg
@@ -188,7 +188,7 @@ function install {
 
 function autoupdate {
   #Add the auto-updater.sh script to the user's crontab
-  crontab -l | { cat; echo "*/10 * * * * /bin/bash -c $CUSTOM_HOME/elrond-go-scripts-v2/auto-updater.sh"; } | crontab -
+  crontab -l 2>/dev/null | { cat; echo "*/10 * * * * /bin/bash -c $CUSTOM_HOME/elrond-go-scripts-v2/auto-updater.sh"; } | crontab -
 }
 
 

--- a/script.sh
+++ b/script.sh
@@ -291,7 +291,7 @@ if [ "$DBQUERY" -eq "1" ]; then
   case $yn in
        [Yy]* )
           echo -e "${GREEN}Adding auto-update to crontab !${NC}"
-          if (crontab -l | grep -q "auto-updater.sh"); then echo "Crontab already installed"; else autoupdate; fi  
+          if (crontab -l 2>/dev/null | grep -q "auto-updater.sh"); then echo "Crontab already installed"; else autoupdate; fi  
             ;;
        [Nn]* )
           echo -e "${GREEN}Fine... let's continue...${NC}"


### PR DESCRIPTION
Suppress the error when installing crontab by redirecting stderr into /dev/null