### PR TITLE
functions.cfg node_name - escape variable

### DIFF
--- a/config/functions.cfg
+++ b/config/functions.cfg
@@ -202,7 +202,7 @@ function node_name {
       NODE_NAME="elrond-validator-$INDEX"
   fi
   
-  sed -i 's/NodeDisplayName = ""/NodeDisplayName = "'$NODE_NAME'"/' $WORKDIR/config/prefs.toml
+  sed -i "s/NodeDisplayName = \"\"/NodeDisplayName = \"${NODE_NAME//\//\\/}\"/" $WORKDIR/config/prefs.toml
 }
 
 function cleanup {


### PR DESCRIPTION
Put the entire thing in double quotes and escape existing double quotes so variables are less troublesome (deals with node names that contains spaces) and does a bash replace on the variable to escape slashes (deals with node names that contain slashes), then ultimately place escaped double quotes around the variable so it ends up in prefs.toml and the node can actually run.