### PR TITLE
script.sh install chown elrond-nodes in case regular user is running …

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -67,6 +67,7 @@ case "$1" in
            echo -e "${GREEN}I'll take that as a no then...${NC}"
             ;;
       esac
+  sudo chown -R $CUSTOM_USER:$CUSTOM_USER $CUSTOM_HOME/elrond-nodes
   ;;
 
 'install-remote')


### PR DESCRIPTION
…with sudo

There's a permissions issue when wanting to run the node as a regular user and the script is run with sudo, hence running chown.