### PR TITLE
Add -j to unzip to remove extra folders when unzipping

### DIFF
--- a/config/functions.cfg
+++ b/config/functions.cfg
@@ -240,7 +240,7 @@ function keys {
                        echo -e
                        echo -e "${GREEN}Found PEMs on host for node-$INDEX. Copying them to node-$INDEX config folder...${NC}"
                        echo -e 
-                       unzip $NODE_KEYS_LOCATION/node-$INDEX.zip -d $WORKDIR/config/
+                       unzip -j $NODE_KEYS_LOCATION/node-$INDEX.zip -d $WORKDIR/config/
                else
                  echo -e
                  echo -e "${GREEN}No PEMs present. Generating private node keys (node will be an observer)...${NC}"


### PR DESCRIPTION
From the manpage (https://linux.die.net/man/1/unzip):

-j
junk paths. The archive's directory structure is not recreated; all files are deposited in the extraction directory (by default, the current one).

---

This is useful when some zip programs create extra folders containing the enclosed files in the zip file.

So let's say that you have your elrond keys in the folder "keys" and zips that entire folder (or the program automatically adds that folder for you), with -j the file structure in the zip file will get normalized/flattened so that only the actual .pem files will be extracted instead of having subdirectories etc get created.