### PR TITLE
Make sure .numberofnodes exists before running commands that depend on it

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -233,19 +233,21 @@ if [ "$DBQUERY" -eq "1" ]; then
        [Yy]* )
           echo -e "${RED}OK ! Cleaning everything !${NC}"
           
-          NODESTODESTROY=$(cat $CUSTOM_HOME/.numberofnodes)
-              for i in $(seq 1 $NODESTODESTROY);
-                  do
-                      KILLINDEX=$(( $i - 1 ))
-                        echo -e
-                        echo -e "${GREEN}Stopping Elrond Node-$KILLINDEX binary on host ${CYAN}$HOST${GREEN}...${NC}"
-                        echo -e
-                        [ -e /etc/systemd/system/elrond-node-$KILLINDEX.service ] && sudo systemctl stop elrond-node-$KILLINDEX
-                        echo -e "${GREEN}Erasing unit file and node folder for Elrond Node-$KILLINDEX...${NC}"
-                        echo -e
-                        [ -e /etc/systemd/system/elrond-node-$KILLINDEX.service ] && sudo rm /etc/systemd/system/elrond-node-$KILLINDEX.service
-                        if [ -d $CUSTOM_HOME/elrond-nodes/node-$KILLINDEX ]; then sudo rm -rf $CUSTOM_HOME/elrond-nodes/node-$KILLINDEX; fi
-                  done
+          if [[ -f $CUSTOM_HOME/.numberofnodes ]]; then
+            NODESTODESTROY=$(cat $CUSTOM_HOME/.numberofnodes)
+                for i in $(seq 1 $NODESTODESTROY);
+                    do
+                        KILLINDEX=$(( $i - 1 ))
+                          echo -e
+                          echo -e "${GREEN}Stopping Elrond Node-$KILLINDEX binary on host ${CYAN}$HOST${GREEN}...${NC}"
+                          echo -e
+                          [ -e /etc/systemd/system/elrond-node-$KILLINDEX.service ] && sudo systemctl stop elrond-node-$KILLINDEX
+                          echo -e "${GREEN}Erasing unit file and node folder for Elrond Node-$KILLINDEX...${NC}"
+                          echo -e
+                          [ -e /etc/systemd/system/elrond-node-$KILLINDEX.service ] && sudo rm /etc/systemd/system/elrond-node-$KILLINDEX.service
+                          if [ -d $CUSTOM_HOME/elrond-nodes/node-$KILLINDEX ]; then sudo rm -rf $CUSTOM_HOME/elrond-nodes/node-$KILLINDEX; fi
+                    done
+          fi
             
             #Reload systemd after deleting node units
             sudo systemctl daemon-reload


### PR DESCRIPTION
If someone runs cleanup as the first command (before any other commands) the script will crash because there's no present .numberofnodes file.

Check if the file exists and only run the relevant code when it does.

Example of failure/crash:
./script.sh cleanup

Do you want to delete installed nodes (Default No) ? (Yy/Nn)y

OK ! Cleaning everything !
cat: /home/deploy/elrond/.numberofnodes: No such file or directory