### PR TITLE
Fix permissions issue for auto-updater

### DIFF
--- a/config/functions.cfg
+++ b/config/functions.cfg
@@ -250,3 +250,13 @@ function keys {
     fi
 
 }
+
+sudofix="/etc/sudoers.d/elrond_systemd"
+function install_sudofix {
+        if [[ "$CUSTOM_USER" != "root" ]]; then
+                echo -e "\n${GREEN}Creating passwordless systemd start+stop sudo for node $INDEX${NC}"
+                echo "$CUSTOM_USER ALL=NOPASSWD: /bin/systemctl stop elrond-node-$INDEX.service" | sudo tee -a $sudofix
+                echo "$CUSTOM_USER ALL=NOPASSWD: /bin/systemctl start elrond-node-$INDEX.service" | sudo tee -a $sudofix
+        fi
+
+}

--- a/script.sh
+++ b/script.sh
@@ -45,6 +45,7 @@ case "$1" in
          node_name
          keys
          systemd
+         install_sudofix
        done
 
   echo -e
@@ -322,7 +323,16 @@ if [ "$DBQUERY" -eq "1" ]; then
 'deploy')
   deploy_to_host
   ;;
-
+  
+'sudofix')
+        INSTALLEDNODES=$(cat $CUSTOM_HOME/.numberofnodes)
+        for i in $(seq 1 $INSTALLEDNODES);
+                do
+                        INDEX=$(( $i - 1 ))
+                        install_sudofix
+                done
+        ;;
+        
 *)
   echo "Usage: Missing parameter ! [install|install-remote|upgrade|upgrade-remote|start|start-remote|stop|stop-remote|cleanup|cleanup-remote]"
   ;;

--- a/script.sh
+++ b/script.sh
@@ -122,7 +122,7 @@ case "$1" in
 'auto_upgrade')
   paths
   #Remove previously cloned repos
-  if [ -d "$GOPATH/src/github.com/ElrondNetwork/elrond-go" ]; then sudo rm -rf $GOPATH/src/github.com/ElrondNetwork/elrond-*; fi
+  if [ -d "$GOPATH/src/github.com/ElrondNetwork/elrond-go" ]; then rm -rf $GOPATH/src/github.com/ElrondNetwork/elrond-*; fi
   git_clone
   build_node
   


### PR DESCRIPTION

Creates narrow security exception for passwordless sudo on systemctl start + stop for elrond-node-*

- Added a function in config/functions.cfg

- Added function call into install routine of script.sh

- Added option in script.sh to patch existing installation

- Omit sudo from rm -rf