### PR TITLE
Update script.sh

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -96,6 +96,7 @@ case "$1" in
 
 'upgrade')
   paths
+  go_lang
   #Remove previously cloned repos  
   if [ -d "$GOPATH/src/github.com/ElrondNetwork/elrond-go" ]; then sudo rm -rf $GOPATH/src/github.com/ElrondNetwork/elrond-*; echo -e; echo -e "${RED}--> Repos present. Removing and fetching again...${NC}"; echo -e; fi
   git_clone
@@ -132,6 +133,7 @@ case "$1" in
 
 'auto_upgrade')
   paths
+  go_lang
   #Remove previously cloned repos
   if [ -d "$GOPATH/src/github.com/ElrondNetwork/elrond-go" ]; then sudo rm -rf $GOPATH/src/github.com/ElrondNetwork/elrond-*; fi
   git_clone


### PR DESCRIPTION
I just deleted Go to see what would happen when running

`cd ~/elrond-go-scripts-v2 && ./script.sh upgrade`
or:
`cd ~/elrond-go-scripts-v2 && ./script.sh auto_upgrade`

This gives bad results. Suggested patch is to add calls to the go_lang function, to install Go if it's not found.