### PR TITLE
hardcoded golang version

### DIFF
--- a/config/functions.cfg
+++ b/config/functions.cfg
@@ -66,9 +66,11 @@ function go_lang {
        #Get the latest version of GO for amd64 & installing it
        echo -e
        echo -e "${RED}GO is not installed on your system${NC}"  
-       GO_LATEST=$(curl -sS https://golang.org/VERSION?m=text)
+       # should not use go latest as the code might not compile with newer versions of GO
+       # GO_LATEST=$(curl -sS https://golang.org/VERSION?m=text)
+       GO_LATEST="go1.13.5"
        echo -e
-       echo -e "${GREEN}The latest version Go is:${CYAN}$GO_LATEST${NC}"
+       echo -e "${GREEN}The best worinking version of Go is:${CYAN}$GO_LATEST${NC}"
        echo -e "${GREEN}Installing it now...${NC}"
        echo -e
        wget https://dl.google.com/go/$GO_LATEST.linux-amd64.tar.gz


### PR DESCRIPTION
hardcoded golang version to 1.13.5 as to not have "unexpected" surprises when a new major version roll out.