### PR TITLE
Feature: auto compile seednode binary when compiling utility binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ The flag for storing into a file the received logger lines is  `-file`
 
 If there's ever a need to start a separate seed/boot node - there's a seednode binary available in the $CUSTOM_HOME/elrond-utils folder.
 This binary will start a new seed node that can be used as a fallback if the primary seed nodes are experiencing issues.
+The seednode requires a p2p.toml file to use for its settings, so you would also have to download that configuration file:
+
+  	  `mkdir -p config && curl -o config/p2p.toml https://raw.githubusercontent.com/ElrondNetwork/elrond-config/master/p2p.toml`
 
   Example:
   	  `./seeednode --help` will display all available arguments/options

--- a/README.md
+++ b/README.md
@@ -169,6 +169,16 @@ The flag for storing into a file the received logger lines is  `-file`
           `./elrond-utils/logviewer -address localhost:8080 -level *:DEBUG,api:INFO -file` will start the binary that will try to connect to the locally-opened 8080 port, will set the log level
       to DEBUG for all packages except api package and will store all captured log lines in a file.
 
+## SEEDNODE INFO
+
+If there's ever a need to start a separate seed/boot node - there's a seednode binary available in the $CUSTOM_HOME/elrond-utils folder.
+This binary will start a new seed node that can be used as a fallback if the primary seed nodes are experiencing issues.
+
+  Example:
+  	  `./seeednode --help` will display all available arguments/options
+      `./seeednode` will start the seed node using the default settings: `--port 10000, --p2p-seed "seed", --log-level "*:INFO "`
+	  `./seeednode --port 12000` will start the seed node using the settings: `--port 12000, --p2p-seed "seed", --log-level "*:INFO "`
+
 ## NODE LOGS INFO  
 
 As of version 1.3.4 of the scripts there is a new command for extracting and tarballing your node logs. The tar file will be stored in the $CUSTOM_HOME/elrond-logs folder and will contain a timestamp in their name.

--- a/config/functions.cfg
+++ b/config/functions.cfg
@@ -177,6 +177,9 @@ function build_node {
   echo -e "${GREEN}Compiling the logviewer binary ...${NC}"
   echo -e
   cd $GOPATH/src/github.com/ElrondNetwork/elrond-go/cmd/logviewer && go build 1> /dev/null 2>&1
+  echo -e "${GREEN}Compiling the seednode binary ...${NC}"
+  echo -e
+  cd $GOPATH/src/github.com/ElrondNetwork/elrond-go/cmd/seednode && go build 1> /dev/null 2>&1
   #Copy libwasmer to a location in path for system wide use
   echo -e "${GREEN}Copying libwasmer to your LIB folder...${NC}"
   echo -e
@@ -207,6 +210,9 @@ function install_utils {
   #Copy the logviewer binary to the utils folder
   if ps -all | grep -q logviewer; then echo "Process running. Terminating for upgrade"; killall logviewer; sleep 2; fi
   cp -f $GOPATH/src/github.com/ElrondNetwork/elrond-go/cmd/logviewer/logviewer $CUSTOM_HOME/elrond-utils/
+  #Copy the seednode binary to the utils folder
+  if ps -all | grep -q seednode; then echo "Process running. Terminating for upgrade"; killall seednode; sleep 2; fi
+  cp -f $GOPATH/src/github.com/ElrondNetwork/elrond-go/cmd/logviewer/seednode $CUSTOM_HOME/elrond-utils/
   #Copy the keygenerator to the utils folder
   cp -f $GOPATH/src/github.com/ElrondNetwork/elrond-go/cmd/keygenerator/keygenerator $CUSTOM_HOME/elrond-utils/ 
 }

--- a/config/functions.cfg
+++ b/config/functions.cfg
@@ -212,7 +212,7 @@ function install_utils {
   cp -f $GOPATH/src/github.com/ElrondNetwork/elrond-go/cmd/logviewer/logviewer $CUSTOM_HOME/elrond-utils/
   #Copy the seednode binary to the utils folder
   if ps -all | grep -q seednode; then echo "Process running. Terminating for upgrade"; killall seednode; sleep 2; fi
-  cp -f $GOPATH/src/github.com/ElrondNetwork/elrond-go/cmd/logviewer/seednode $CUSTOM_HOME/elrond-utils/
+  cp -f $GOPATH/src/github.com/ElrondNetwork/elrond-go/cmd/seednode/seednode $CUSTOM_HOME/elrond-utils/
   #Copy the keygenerator to the utils folder
   cp -f $GOPATH/src/github.com/ElrondNetwork/elrond-go/cmd/keygenerator/keygenerator $CUSTOM_HOME/elrond-utils/ 
 }

--- a/script.sh
+++ b/script.sh
@@ -275,6 +275,9 @@ if [ "$DBQUERY" -eq "1" ]; then
               
             if ps -all | grep -q logviewer; then killall logviewer; sleep 2; fi
             if [[ -e $CUSTOM_HOME/elrond-utils/logviewer ]]; then rm $CUSTOM_HOME/elrond-utils/logviewer; fi
+
+            if ps -all | grep -q seednode; then killall seednode; sleep 2; fi
+            if [[ -e $CUSTOM_HOME/elrond-utils/seednode ]]; then rm $CUSTOM_HOME/elrond-utils/seednode; fi
             
             rm -rf $CUSTOM_HOME/elrond-utils && rm -rf $CUSTOM_HOME/elrond-nodes
             if [[ -e $CUSTOM_HOME/autoupdate.status ]]; then rm $CUSTOM_HOME/autoupdate.status; fi 


### PR DESCRIPTION
Today an insane amount of nodes went offline because of the official Battle of Nodes seed nodes were experiencing issues.

With this PR the `seednode` binary will automatically get compiled and copied to the `$CUSTOM_HOME/elrond-utils` folder.

This will make it a lot easier for the Elrond community members to start their own seed nodes in order to help out the network and improve peer connectivity when the official seed nodes are struggling.

Example usage:

1. `./script.sh install` (will now also install the `seednode` binary to `$CUSTOM_HOME/elrond-utils`)
2. `cd $CUSTOM_HOME/elrond-utils`
3. `mkdir -p config && curl -o config/p2p.toml https://raw.githubusercontent.com/ElrondNetwork/elrond-config/master/p2p.toml`
4. `./seednode`