### PR TITLE
Add Keybase identity to variables.cfg

### DIFF
--- a/config/variables.cfg
+++ b/config/variables.cfg
@@ -16,6 +16,7 @@ CUSTOM_USER="ubuntu"
 NODE_KEYS_LOCATION="$CUSTOM_HOME/VALIDATOR_KEYS"
 SSHPORT="22"
 GITHUBTOKEN=""
+INDENTITY="" #keybaseid
 #------------------------------------------------------------------------------------------#
 
 #-------------------------------#### DON'T CHANGE THESE ####-------------------------------#


### PR DESCRIPTION
It can be awesome if we add identity variable and make that all the nodes installed have the same Keybase id. We spent a lot of time editing this by hand later in elrond-nodes/node-0/config/prefs.toml