### PR TITLE
Don't assume group when using chown

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -76,7 +76,7 @@ case "$1" in
            echo -e "${GREEN}I'll take that as a no then...${NC}"
             ;;
       esac
-  sudo chown -R $CUSTOM_USER $CUSTOM_HOME/elrond-nodes
+  sudo chown -R $CUSTOM_USER: $CUSTOM_HOME/elrond-nodes
   ;;
 
 'install-remote')

--- a/script.sh
+++ b/script.sh
@@ -76,7 +76,7 @@ case "$1" in
            echo -e "${GREEN}I'll take that as a no then...${NC}"
             ;;
       esac
-  sudo chown -R $CUSTOM_USER:$CUSTOM_USER $CUSTOM_HOME/elrond-nodes
+  sudo chown -R $CUSTOM_USER $CUSTOM_HOME/elrond-nodes
   ;;
 
 'install-remote')


### PR DESCRIPTION
A user *must* belong to one primary group, but that group does not necessarily share a name with that user (even on Ubuntu).
It should suffice to change the user who owns the file.
If you want to change the group as well (and use the user's default/login group), you can put a `:` after the user's name but omit the group name.
The behavior is explained in the first paragraph of the man page:  https://linux.die.net/man/1/chown

```
sudo chown -R $CUSTOM_USER: $CUSTOM_HOME/elrond-nodes  
```